### PR TITLE
Update apt source, ensure update before package install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,9 +36,9 @@
 # Copyright 2015 Open Source Robotics Foundation, Inc.
 #
 class ros {
-  include ros::params
-  include ros::install
-  include ros::rosdep
+  require ros::params
+  require ros::install
+  require ros::rosdep
 
   $setup_file = "/opt/ros/${ros::params::ros_version}/setup.bash"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,4 +40,6 @@ class ros {
   include ros::install
   include ros::rosdep
 
+  $setup_file = "/opt/ros/${ros::params::ros_version}/setup.bash"
+
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,32 +7,42 @@ class ros::install {
 
 
   apt::source { 'ros-latest':
-    location     => $ros::params::repo_url,
-    #release      => 'stable',
-    repos        => $ros::params::repo_component,
-    key          => $ros::params::repo_key,
-    key_source   => $ros::params::repo_key_url,
-    include_src  => true,
+    location => $ros::params::repo_url,
+    #release => 'stable',
+    repos    => $ros::params::repo_component,
+    key      => {
+      id     => $ros::params::repo_key,
+      server => $ros::params::repo_key_url
+      },
+    include  => { src => true }
   }
 
   package { $ros::params::ros_base_package:
     ensure  => 'installed',
-    require => Apt::Source ['ros-latest'],
+    require => [ Apt::Source['ros-latest'],
+                 Class['apt::update']
+                 ]
   }
 
   package { 'python-rosdep':
     ensure  => 'installed',
-    require => Apt::Source ['ros-latest'],
+    require => [ Apt::Source['ros-latest'],
+                 Class['apt::update']
+                 ]
   }
 
   package { 'python-rosinstall':
     ensure  => 'installed',
-    require => Apt::Source ['ros-latest'],
+    require => [ Apt::Source['ros-latest'],
+                 Class['apt::update']
+                 ]
   }
 
   package { 'python-rosdistro':
     ensure  => 'latest',
-    require => Apt::Source ['ros-latest'],
+    require => [ Apt::Source['ros-latest'],
+                 Class['apt::update']
+                 ]
   }
 
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,6 +1,6 @@
 define ros::package ($ensure='installed', $require=[]) {
-  include ros
-  include ros::params
+  require ros
+  require ros::params
   package { "ros-${ros::params::ros_version}-${title}":
     ensure  => $ensure,
     require => [Class['ros']] + $require

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,0 +1,8 @@
+define ros::package ($ensure='installed', $require=[]) {
+  include ros
+  include ros::params
+  package { "ros-${ros::params::ros_version}-${title}":
+    ensure  => $ensure,
+    require => [Class['ros']] + $require
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,8 +11,8 @@ class ros::params {
 
   case $::operatingsystem {
     Ubuntu: {
-      $repo_key         = 'B01FA116'
-      $repo_key_url     = 'https://raw.githubusercontent.com/ros/rosdistro/master/ros.key'
+      $repo_key         = '421C365BD9FF1F717815A3895523BAEEB01FA116'
+      $repo_key_url     = 'hkp://ha.pool.sks-keyservers.net'
       $repo_url         = 'http://packages.ros.org/ros/ubuntu'
       $repo_component   = 'main'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class ros::params {
           $ros_version     = 'jade'
         }
         default: { # latest lts
-          $ros_version     = 'indigo'
+          $ros_version     = 'kinetic'
         }
 
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class ros::params {
   #  python3
 
   case $::operatingsystem {
-    Ubuntu: {
+    'Ubuntu': {
       $repo_key         = '421C365BD9FF1F717815A3895523BAEEB01FA116'
       $repo_key_url     = 'hkp://ha.pool.sks-keyservers.net'
       $repo_url         = 'http://packages.ros.org/ros/ubuntu'

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/tfoote/puppet-ros/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-apt","version_requirement":">= 1.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
- Updated apt::source to get rid of deprecation warnings.
- Ensure update before package installs as recommended in [puppetlabs-apt-readme](https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas).
- Use keyserver from [ROS wiki instructions](http://wiki.ros.org/indigo/Installation/Ubuntu#indigo.2BAC8-Installation.2BAC8-Sources.Set_up_your_keys) and 40 bytes key fingerprint.
